### PR TITLE
spheres suck, use ellipsoids

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@darkskyapp",
+  "rules": {
+    "max-len": [2, 120]
+  }
+}

--- a/index.js
+++ b/index.js
@@ -126,20 +126,20 @@ function overlaps_any(a, bs) {
 }
 
 function bearing(lat_1, lon_1, lat_2, lon_2) {
-  let azi = GeographicLib.Geodesic.WGS84.Inverse(
+  let {azi1} = GeographicLib.Geodesic.WGS84.Inverse(
     lat_1,
     lon_1,
     lat_2,
     lon_2,
     GeographicLib.Geodesic.AZIMUTH
-  ).azi1;
+  );
 
   // GeographicLib returns -180..180, we want 0..360.
-  if(azi < 0) {
-    azi += 360;
+  if(azi1 < 0) {
+    azi1 += 360;
   }
 
-  return azi;
+  return azi1;
 }
 
 function distance(lat_1, lon_1, lat_2, lon_2) {

--- a/index.js
+++ b/index.js
@@ -1,16 +1,14 @@
 "use strict";
-const DEGREES = 180 / Math.PI;
-const EARTH_RADIUS = 6371008.8;
-const RADIANS = Math.PI / 180;
+const GeographicLib = require("geographiclib");
 
 function centroid(a) {
-  /* Optimization: the centroid of a point is, well, a point; so simply return
-   * it as-is in order to prevent an allocation from being necessary. */
+  // Optimization: the centroid of a point is, well, a point; so simply return
+  // it as-is in order to prevent an allocation from being necessary.
   if(a.length <= 2) {
     return a;
   }
 
-  /* The centroid is merely the average of all the coordinates of a shape. */
+  // The centroid is merely the average of all the coordinates of a shape.
   let x = 0;
   let y = 0;
   let n = 0;
@@ -22,24 +20,23 @@ function centroid(a) {
   return [x, y];
 }
 
-/* Overlap test that works for any combination of points and boxes. */
+// Overlap test that works for any combination of points and boxes.
 function box_box(a, b) {
-  const m = a.length,
-        n = b.length;
-  return a[0] <= b[n - 2] && a[1] <= b[n - 1] &&
-         a[m - 2] >= b[0] && a[m - 1] >= b[1];
+  const m = a.length;
+  const n = b.length;
+  return a[0] <= b[n - 2] && a[1] <= b[n - 1] && a[m - 2] >= b[0] && a[m - 1] >= b[1];
 }
 
-/* A point and a polygon overlap if the point is within the polygon.
- * See: http://paulbourke.net/geometry/polygonmesh/#insidepoly */
+// A point and a polygon overlap if the point is within the polygon.
+// See: http://paulbourke.net/geometry/polygonmesh/#insidepoly
 function polygon_point(a, b) {
-  let contains = false,
-      x1 = a[0],
-      y1 = a[1],
-      x2 = NaN,
-      y2 = NaN;
-  const x = b[0],
-        y = b[1];
+  let contains = false;
+  let x1 = a[0];
+  let y1 = a[1];
+  let x2 = NaN;
+  let y2 = NaN;
+  const x = b[0];
+  const y = b[1];
 
   for(let i = a.length; i; ) {
     y2 = y1;
@@ -58,31 +55,31 @@ function polygon_point(a, b) {
 }
 
 function polygon_polygon(a, b) {
-  /* A point of B is wholly within A. */
+  // A point of B is wholly within A.
   if(polygon_point(a, b)) {
     return true;
   }
 
-  /* A point of A is wholly within B. */
+  // A point of A is wholly within B.
   if(polygon_point(b, a)) {
     return true;
   }
 
-  /* Any edge of A and B cross. */
-  let ax1 = a[0],
-      ay1 = a[1],
-      ax2 = NaN,
-      ay2 = NaN;
+  // Any edge of A and B cross.
+  let ax1 = a[0];
+  let ay1 = a[1];
+  let ax2 = NaN;
+  let ay2 = NaN;
   for(let i = a.length; i; ) {
     ay2 = ay1;
     ax2 = ax1;
     ay1 = a[--i];
     ax1 = a[--i];
 
-    let bx1 = b[0],
-        by1 = b[1],
-        bx2 = NaN,
-        by2 = NaN;
+    let bx1 = b[0];
+    let by1 = b[1];
+    let bx2 = NaN;
+    let by2 = NaN;
     for(let j = b.length; j; ) {
       by2 = by1;
       bx2 = bx1;
@@ -101,7 +98,7 @@ function polygon_polygon(a, b) {
   return false;
 }
 
-/* We cheese out and convert boxes to polygons and use the poly-poly test. */
+// We cheese out and convert boxes to polygons and use the poly-poly test.
 function polygon_box(a, b) {
   return polygon_polygon(a, [b[0], b[1], b[2], b[1], b[2], b[3], b[1], b[3]]);
 }
@@ -113,10 +110,10 @@ function overlaps(a, b) {
     b = t;
   }
 
-  return (a.length <= 4)? box_box        (a, b):
-         (b.length <= 2)? polygon_point  (a, b):
-         (b.length <= 4)? polygon_box    (a, b):
-                          polygon_polygon(a, b);
+  if(a.length <= 4) { return box_box(a, b); }
+  if(b.length <= 2) { return polygon_point(a, b); }
+  if(b.length <= 4) { return polygon_box(a, b); }
+  return polygon_polygon(a, b);
 }
 
 function overlaps_any(a, bs) {
@@ -128,48 +125,36 @@ function overlaps_any(a, bs) {
   return false;
 }
 
-/* distance + bearing below are sourced from
- * http://www.movable-type.co.uk/scripts/latlong.html */
-function bearing(lat1, lon1, lat2, lon2) {
-  lat1 *= RADIANS;
-  lon1 *= RADIANS;
-  lat2 *= RADIANS;
-  lon2 *= RADIANS;
+function bearing(lat_1, lon_1, lat_2, lon_2) {
+  let azi = GeographicLib.Geodesic.WGS84.Inverse(
+    lat_1,
+    lon_1,
+    lat_2,
+    lon_2,
+    GeographicLib.Geodesic.AZIMUTH
+  ).azi1;
 
-  const dLon = lon2 - lon1;
+  // GeographicLib returns -180..180, we want 0..360.
+  if(azi < 0) {
+    azi += 360;
+  }
 
-  return (Math.atan2(
-    Math.sin(dLon) * Math.cos(lat2),
-    Math.cos(lat1) * Math.sin(lat2) -
-      Math.sin(lat1) * Math.cos(lat2) * Math.cos(dLon)
-  ) * DEGREES + 360.0) % 360.0;
+  return azi;
 }
 
 function distance(lat_1, lon_1, lat_2, lon_2) {
-  lat_1 *= RADIANS;
-  lon_1 *= RADIANS;
-  lat_2 *= RADIANS;
-  lon_2 *= RADIANS;
-
-  const dLon = lon_2 - lon_1;
-  const sinDLon = Math.sin(dLon);
-  const cosDLon = Math.cos(dLon);
-  const sinLat1 = Math.sin(lat_1);
-  const cosLat1 = Math.cos(lat_1);
-  const sinLat2 = Math.sin(lat_2);
-  const cosLat2 = Math.cos(lat_2);
-  const a = cosLat2 * sinDLon;
-  const b = cosLat1 * sinLat2 - sinLat1 * cosLat2 * cosDLon;
-
-  return EARTH_RADIUS * Math.atan2(
-    Math.hypot(a, b),
-    sinLat1 * sinLat2 + cosLat1 * cosLat2 * cosDLon
-  );
+  return GeographicLib.Geodesic.WGS84.Inverse(
+    lat_1,
+    lon_1,
+    lat_2,
+    lon_2,
+    GeographicLib.Geodesic.DISTANCE
+  ).s12;
 }
 
 function distance_any(a, bs) {
   const m = centroid(a);
-  let min_dist = EARTH_RADIUS * Math.PI;
+  let min_dist = Infinity;
   for(const b of bs) {
     const n = centroid(b);
     const dist = distance(m[0], m[1], n[0], n[1]);
@@ -180,10 +165,9 @@ function distance_any(a, bs) {
   return min_dist;
 }
 
-exports.EARTH_RADIUS = EARTH_RADIUS;
-exports.centroid     = centroid;
-exports.overlaps     = overlaps;
+exports.centroid = centroid;
+exports.overlaps = overlaps;
 exports.overlaps_any = overlaps_any;
-exports.bearing      = bearing;
-exports.distance     = distance;
+exports.bearing = bearing;
+exports.distance = distance;
 exports.distance_any = distance_any;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geo-shapes",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Utility functions for points and polygons",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "Utility functions for points and polygons",
   "main": "index.js",
   "scripts": {
-    "lint": "jshint . --exclude node_modules",
-    "test": "NODE_ENV=test istanbul cover _mocha -- $ARGS"
+    "cover": "NODE_ENV=test nyc --reporter=html --reporter=text-summary mocha",
+    "lint": "eslint .",
+    "lint-fix": "eslint --fix .",
+    "test": "npm run lint && npm run cover"
   },
   "repository": {
     "type": "git",
@@ -25,37 +27,16 @@
     "url": "https://github.com/darkskyapp/geo-shapes/issues"
   },
   "homepage": "https://github.com/darkskyapp/geo-shapes#readme",
-  "devDependencies": {
-    "chai": "^3.5.0",
-    "istanbul": "^0.4.5",
-    "jshint": "^2.9.4",
-    "mocha": "^3.4.2"
+  "dependencies": {
+    "geographiclib": "^1.49.0"
   },
-  "jshintConfig": {
-    "esnext": true,
-    "curly": true,
-    "eqeqeq": true,
-    "forin": true,
-    "freeze": true,
-    "immed": true,
-    "indent": 2,
-    "latedef": true,
-    "maxlen": 79,
-    "mocha": true,
-    "newcap": true,
-    "noarg": true,
-    "node": true,
-    "noempty": true,
-    "nonbsp": true,
-    "nonew": true,
-    "predef": [
-      "-Promise"
-    ],
-    "quotmark": "double",
-    "sub": true,
-    "strict": true,
-    "undef": true,
-    "unused": "vars",
-    "varstmt": true
+  "devDependencies": {
+    "@darkskyapp/eslint-config": "^1.1.1",
+    "chai": "^4.2.0",
+    "eslint": "^5.14.0",
+    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "mocha": "^5.2.0",
+    "nyc": "^14.1.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -33,82 +33,82 @@ describe("geo-shapes", () => {
     });
 
     it("should return false for a polygon that doesn't contain a point", () => { // jshint ignore:line
-        const point = [0, 0];
+      const point = [0, 0];
 
-        const polygon = [
-          -2,  0,
-           0, -2,
-           2,  0,
-           0,  2,
-          -2,  0,
-          -1,  0,
-           0,  1,
-           1,  0,
-           0, -1,
-          -1,  0
-        ];
+      const polygon = [
+        -2, 0,
+        0, -2,
+        2, 0,
+        0, 2,
+        -2, 0,
+        -1, 0,
+        0, 1,
+        1, 0,
+        0, -1,
+        -1, 0,
+      ];
 
-        expect(geoshapes.overlaps(point, polygon)).to.equal(false);
-        expect(geoshapes.overlaps(polygon, point)).to.equal(false);
-      }
+      expect(geoshapes.overlaps(point, polygon)).to.equal(false);
+      expect(geoshapes.overlaps(polygon, point)).to.equal(false);
+    }
     );
 
     it("should return true for a polygon that does contain a point", () => {
-        const point = [-1.5, 0];
+      const point = [-1.5, 0];
 
-        const polygon = [
-          -2,  0,
-           0, -2,
-           2,  0,
-           0,  2,
-          -2,  0,
-          -1,  0,
-           0,  1,
-           1,  0,
-           0, -1,
-          -1,  0
-        ];
+      const polygon = [
+        -2, 0,
+        0, -2,
+        2, 0,
+        0, 2,
+        -2, 0,
+        -1, 0,
+        0, 1,
+        1, 0,
+        0, -1,
+        -1, 0,
+      ];
 
-        expect(geoshapes.overlaps(point, polygon)).to.equal(true);
-        expect(geoshapes.overlaps(polygon, point)).to.equal(true);
-      }
+      expect(geoshapes.overlaps(point, polygon)).to.equal(true);
+      expect(geoshapes.overlaps(polygon, point)).to.equal(true);
+    }
     );
 
     it("should return false for a polygon that doesn't overlap a box", () => {
-        const box = [-0.4, -0.4, 0.4, 0.4];
+      const box = [-0.4, -0.4, 0.4, 0.4];
 
-        const polygon = [
-          -2,  0,
-           0, -2,
-           2,  0,
-           0,  2,
-          -2,  0,
-          -1,  0,
-           0,  1,
-           1,  0,
-           0, -1,
-          -1,  0
-        ];
+      const polygon = [
+        -2, 0,
+        0, -2,
+        2, 0,
+        0, 2,
+        -2, 0,
+        -1, 0,
+        0, 1,
+        1, 0,
+        0, -1,
+        -1, 0,
+      ];
 
-        expect(geoshapes.overlaps(box, polygon)).to.equal(false);
-        expect(geoshapes.overlaps(polygon, box)).to.equal(false);
-      }
+      expect(geoshapes.overlaps(box, polygon)).to.equal(false);
+      expect(geoshapes.overlaps(polygon, box)).to.equal(false);
+    }
     );
 
     it("should return true for a polygon that overlaps a box", () => {
       const box = [-0.6, -0.6, 0.6, 0.6];
 
       const polygon = [
-        -2,  0,
-         0, -2,
-         2,  0,
-         0,  2,
-        -2,  0,
-        -1,  0,
-         0,  1,
-         1,  0,
-         0, -1,
-        -1,  0
+        -2, 0,
+        0, -2,
+        2, 0,
+        0, 2,
+        -2, 0,
+        -1, 0,
+        0, 1,
+        1, 0,
+        0, -1,
+        -1, 0,
       ];
 
       expect(geoshapes.overlaps(box, polygon)).to.equal(true);
@@ -116,23 +116,23 @@ describe("geo-shapes", () => {
     });
 
     it("should return false for two polygons that don't overlap", () => {
-        expect(
-            geoshapes.overlaps(
-              [-1, 0, -2, 1, -2, -1],
-              [0, 0, -2, -2, 2, -2, 2, 2, -2, 2]
-            )
-          ).
-          to.equal(false);
-      }
+      expect(
+        geoshapes.overlaps(
+          [-1, 0, -2, 1, -2, -1],
+          [0, 0, -2, -2, 2, -2, 2, 2, -2, 2]
+        )
+      ).
+        to.equal(false);
+    }
     );
 
     it("should return true for two polygons that intersect", () => {
       expect(
-          geoshapes.overlaps(
-            [ 1, 0, -1,  2, -3, 0, -1, -2],
-            [-1, 0,  1, -2,  3, 0,  1,  2]
-          )
-        ).
+        geoshapes.overlaps(
+          [ 1, 0, -1, 2, -3, 0, -1, -2],
+          [-1, 0, 1, -2, 3, 0, 1, 2]
+        )
+      ).
         to.equal(true);
     });
 
@@ -148,14 +148,14 @@ describe("geo-shapes", () => {
   describe("distance", () => {
     it("should return the distance between Nashville and LA", () => {
       expect(geoshapes.distance(36.12, -86.67, 33.94, -118.4)).
-        to.be.closeTo(2860000, 26481);
+        to.be.closeTo(2892777, 1);
     });
 
     it("should return the distance between the north + south pole", () => {
       expect(geoshapes.distance(90, 0, -90, 0)).
-        to.be.closeTo(20015114, 1);
+        to.be.closeTo(20003931, 1);
       expect(geoshapes.distance(0, 0, 0, 180.0)).
-        to.be.closeTo(20015114, 1);
+        to.be.closeTo(20003931, 1);
     });
   });
   describe("bearing", function() {
@@ -166,7 +166,7 @@ describe("geo-shapes", () => {
 
     it("should give a bearing of ~300 degrees from Osaka to Baghdad", () => {
       expect(geoshapes.bearing(35.0, 135.0, 35.0, 45.0)).
-      to.be.closeTo(300.0, 1);
+        to.be.closeTo(300.0, 1);
     });
   });
 });


### PR DESCRIPTION
This PR does the following:

1. Stop using a reference sphere and instead use the WGS84 reference spheroid for distance and bearing calculations. (Do you think I did that myself? _Hell no!_ I used the JS library noted by the person who _literally wrote the paper_ on the topic.) Fix #2
2. I updated all the dev dependencies and code style to match how we do things these days.