### PR TITLE
refactor interface for greater speed

### DIFF
--- a/lib/geodesy.js
+++ b/lib/geodesy.js
@@ -2,44 +2,25 @@
 const GeographicLib = require("geographiclib");
 
 const EARTH_RADIUS = 6371008.8;
-const DISTANCE = Symbol();
-const AZIMUTH = Symbol();
-const ALL = Symbol();
 
 
-const hypot = Math.hypot;
+function exact(lat_1, lon_1, lat_2, lon_2) {
+  const {s12, azi1} = GeographicLib.Geodesic.WGS84.Inverse(
+    lat_1,
+    lon_1,
+    lat_2,
+    lon_2,
+    GeographicLib.Geodesic.DISTANCE | GeographicLib.Geodesic.AZIMUTH
+  );
 
-function wrap(x) {
-  if(x < 0) {
-    x += 360;
-  }
-  return x;
-}
-
-function atan(y, x) {
-  return wrap(Math.atan2(y, x) * (180 / Math.PI));
-}
-
-
-function exact(lat_1, lon_1, lat_2, lon_2, retval=ALL) {
-  let flags = 0;
-  switch(retval) {
-    case DISTANCE: flags = GeographicLib.Geodesic.DISTANCE; break;
-    case AZIMUTH: flags = GeographicLib.Geodesic.AZIMUTH; break;
-    case ALL: flags = GeographicLib.Geodesic.DISTANCE | GeographicLib.Geodesic.AZIMUTH; break;
-    default: throw new RangeError("expected one of DISTANCE, AZIMUTH, ALL");
-  }
-
-  const {s12, azi1} = GeographicLib.Geodesic.WGS84.Inverse(lat_1, lon_1, lat_2, lon_2, flags);
-  switch(retval) {
-    case DISTANCE: return s12;
-    case AZIMUTH: return wrap(azi1);
-    case ALL: return {distance: s12, azimuth: wrap(azi1)};
-  }
+  return {
+    distance: s12,
+    azimuth: (azi1 + 360) % 360,
+  };
 }
 
 // https://www.govinfo.gov/content/pkg/CFR-2016-title47-vol4/pdf/CFR-2016-title47-vol4-sec73-208.pdf
-function approximate(lat_1, lon_1, lat_2, lon_2, retval=ALL) {
+function approximate(lat_1, lon_1, lat_2, lon_2) {
   // Cast everything to numbers, just in case.
   lat_1 = +lat_1;
   lon_1 = +lon_1;
@@ -60,19 +41,42 @@ function approximate(lat_1, lon_1, lat_2, lon_2, retval=ALL) {
   const d_lat = k_lat * (lat_2 - lat_1);
   const d_lon = k_lon * (lon_2 - lon_1);
 
-  switch(retval) {
-    case DISTANCE: return hypot(d_lon, d_lat);
-    case AZIMUTH: return atan(d_lon, d_lat);
-    case ALL: return {distance: hypot(d_lon, d_lat), azimuth: atan(d_lon, d_lat)};
-    default: throw new RangeError("expected one of DISTANCE, AZIMUTH, ALL");
-  }
+  return {
+    distance: Math.sqrt(d_lat * d_lat + d_lon * d_lon),
+    azimuth: (Math.atan2(d_lon, d_lat) * (180 / Math.PI) + 360) % 360,
+  };
+}
+
+// This function is nearly identical to the above one, but it only returns the
+// square of the distance. It is suitable for applications requiring modest
+// accuracy and great speed.
+function distance_sq(lat_1, lon_1, lat_2, lon_2) {
+  // Cast everything to numbers, just in case.
+  lat_1 = +lat_1;
+  lon_1 = +lon_1;
+  lat_2 = +lat_2;
+  lon_2 = +lon_2;
+
+  // https://en.wikipedia.org/wiki/Chebyshev_polynomials
+  const cos_0m = 1;
+  const cos_1m = Math.cos((lat_1 + lat_2) * (Math.PI / 360));
+  const cos_2m = 2 * cos_1m * cos_1m - cos_0m;
+  const cos_3m = 2 * cos_1m * cos_2m - cos_1m;
+  const cos_4m = 2 * cos_1m * cos_3m - cos_2m;
+  const cos_5m = 2 * cos_1m * cos_4m - cos_3m;
+
+  const k_lat = 111132.09 * cos_0m - 566.05 * cos_2m + 1.20 * cos_4m;
+  const k_lon = 111415.13 * cos_1m - 94.55 * cos_3m + 0.12 * cos_5m;
+
+  const d_lat = k_lat * (lat_2 - lat_1);
+  const d_lon = k_lon * (lon_2 - lon_1);
+
+  return d_lat * d_lat + d_lon * d_lon;
 }
 
 
 exports.EARTH_RADIUS = EARTH_RADIUS;
-exports.DISTANCE = DISTANCE;
-exports.AZIMUTH = AZIMUTH;
-exports.ALL = ALL;
 
 exports.exact = exact;
 exports.approximate = approximate;
+exports.distance_sq = distance_sq;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geo-shapes",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Utility functions for points and polygons",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -193,30 +193,41 @@ describe("geo-shapes", () => {
         ]) {
           const approximate = geo_shapes.geodesy.approximate(lat_1, lon_1, lat_2, lon_2);
           const exact = geo_shapes.geodesy.exact(lat_1, lon_1, lat_2, lon_2);
+          const approximate_sq = geo_shapes.geodesy.distance_sq(lat_1, lon_1, lat_2, lon_2);
 
           expect(approximate.distance).to.be.closeTo(exact.distance, 0.1);
           expect(approximate.azimuth).to.be.closeTo(exact.azimuth, 0.1);
+          expect(approximate_sq).to.be.closeTo(approximate.distance * approximate.distance, 0.1);
         }
       });
     });
 
     describe("exact", () => {
       it("should return the distance between Nashville and LA", () => {
-        expect(geo_shapes.geodesy.exact(36.12, -86.67, 33.94, -118.4, geo_shapes.geodesy.DISTANCE)).
-          to.be.closeTo(2892777, 1);
+        expect(geo_shapes.geodesy.exact(36.12, -86.67, 33.94, -118.4)).
+          to.have.a.property("distance").
+          that.is.closeTo(2892777, 1);
       });
 
       it("should return the distance between the north + south pole", () => {
-        expect(geo_shapes.geodesy.exact(90, 0, -90, 0, geo_shapes.geodesy.DISTANCE)).to.be.closeTo(20003931, 1);
-        expect(geo_shapes.geodesy.exact(0, 0, 0, 180, geo_shapes.geodesy.DISTANCE)).to.be.closeTo(20003931, 1);
+        expect(geo_shapes.geodesy.exact(90, 0, -90, 0)).
+          to.have.a.property("distance").
+          that.is.closeTo(20003931, 1);
+        expect(geo_shapes.geodesy.exact(0, 0, 0, 180)).
+          to.have.a.property("distance").
+          that.is.closeTo(20003931, 1);
       });
 
       it("should give a bearing of ~60 degrees from Baghdad to Osaka", () => {
-        expect(geo_shapes.geodesy.exact(35, 45, 35, 135, geo_shapes.geodesy.AZIMUTH)).to.be.closeTo(60, 1);
+        expect(geo_shapes.geodesy.exact(35, 45, 35, 135)).
+          to.have.a.property("azimuth").
+          that.is.closeTo(60, 1);
       });
 
       it("should give a geodesy.exact of ~300 degrees from Osaka to Baghdad", () => {
-        expect(geo_shapes.geodesy.exact(35, 135, 35, 45, geo_shapes.geodesy.AZIMUTH)).to.be.closeTo(300, 1);
+        expect(geo_shapes.geodesy.exact(35, 135, 35, 45)).
+          to.have.a.property("azimuth").
+          that.is.closeTo(300, 1);
       });
     });
   });


### PR DESCRIPTION
While testing, we found that `Math.hypot()` allocates arrays internally, which is ridiculously slow. Further, we found that we don't really need the `Math.sqrt()` anyway, since we're comparing against thresholds. So, this breaking change refactors the interface to better suit our needs:

1. I got rid of the complicated "select what you want" flags. `exact` and `approximate` just both return everything.
2. I added a separate `distance_sq` function which is intended for raw speed applications.
3. I got rid of `Math.hypot` in favor of `Math.sqrt()` in the case we used it for.